### PR TITLE
Use BB logic for tree/portal creation

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -72,12 +72,12 @@ import org.bukkit.metadata.MetadataValue;
 import org.bukkit.projectiles.BlockProjectileSource;
 import org.bukkit.projectiles.ProjectileSource;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
@@ -629,26 +629,9 @@ public class BlockEventHandler implements Listener
             if (!isRetract && direction == BlockFace.DOWN) return;
         }
 
-        // Assemble list of potentially intersecting claims from chunks interacted with.
-        ArrayList<Claim> intersectable = new ArrayList<>();
-        int chunkXMax = movedBlocks.getMaxX() >> 4;
-        int chunkZMax = movedBlocks.getMaxZ() >> 4;
-
-        for (int chunkX = movedBlocks.getMinX() >> 4; chunkX <= chunkXMax; ++chunkX)
-        {
-            for (int chunkZ = movedBlocks.getMinZ() >> 4; chunkZ <= chunkZMax; ++chunkZ)
-            {
-                ArrayList<Claim> chunkClaims = dataStore.chunksToClaimsMap.get(DataStore.getChunkHash(chunkX, chunkZ));
-                if (chunkClaims == null) continue;
-
-                for (Claim claim : chunkClaims)
-                {
-                    // Ensure claim is not piston claim and is in same world.
-                    if (pistonClaim != claim && pistonBlock.getWorld().equals(claim.getLesserBoundaryCorner().getWorld()))
-                        intersectable.add(claim);
-                }
-            }
-        }
+        // Get claims in the chunks intersecting with the moved blocks.
+        Set<Claim> intersectable = dataStore.getChunkClaims(pistonBlock.getWorld(), movedBlocks);
+        if (pistonClaim != null) intersectable.remove(pistonClaim);
 
         BiPredicate<Claim, BoundingBox> intersectionHandler;
         final Claim finalPistonClaim = pistonClaim;

--- a/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -27,6 +27,7 @@ import me.ryanhamshire.GriefPrevention.events.ClaimCreatedEvent;
 import me.ryanhamshire.GriefPrevention.events.ClaimDeletedEvent;
 import me.ryanhamshire.GriefPrevention.events.ClaimExtendEvent;
 import me.ryanhamshire.GriefPrevention.events.ClaimTransferEvent;
+import me.ryanhamshire.GriefPrevention.util.BoundingBox;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Chunk;
@@ -42,6 +43,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.Tameable;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -819,6 +821,32 @@ public abstract class DataStore
         {
             return Collections.unmodifiableCollection(new ArrayList<>());
         }
+    }
+
+    public @NotNull Set<Claim> getChunkClaims(@NotNull World world, @NotNull BoundingBox boundingBox)
+    {
+        Set<Claim> claims = new HashSet<>();
+        int chunkXMax = boundingBox.getMaxX() >> 4;
+        int chunkZMax = boundingBox.getMaxZ() >> 4;
+
+        for (int chunkX = boundingBox.getMinX() >> 4; chunkX <= chunkXMax; ++chunkX)
+        {
+            for (int chunkZ = boundingBox.getMinZ() >> 4; chunkZ <= chunkZMax; ++chunkZ)
+            {
+                ArrayList<Claim> chunkClaims = this.chunksToClaimsMap.get(getChunkHash(chunkX, chunkZ));
+                if (chunkClaims == null) continue;
+
+                for (Claim claim : chunkClaims)
+                {
+                    if (claim.inDataStore && world.equals(claim.getLesserBoundaryCorner().getWorld()))
+                    {
+                        claims.add(claim);
+                    }
+                }
+            }
+        }
+
+        return claims;
     }
 
     //gets an almost-unique, persistent identifier for a chunk
@@ -1946,32 +1974,9 @@ public abstract class DataStore
     //gets all the claims "near" a location
     Set<Claim> getNearbyClaims(Location location)
     {
-        Set<Claim> claims = new HashSet<>();
-
-        Chunk lesserChunk = location.getWorld().getChunkAt(location.subtract(150, 0, 150));
-        Chunk greaterChunk = location.getWorld().getChunkAt(location.add(300, 0, 300));
-
-        for (int chunk_x = lesserChunk.getX(); chunk_x <= greaterChunk.getX(); chunk_x++)
-        {
-            for (int chunk_z = lesserChunk.getZ(); chunk_z <= greaterChunk.getZ(); chunk_z++)
-            {
-                Chunk chunk = location.getWorld().getChunkAt(chunk_x, chunk_z);
-                Long chunkID = getChunkHash(chunk.getBlock(0, 0, 0).getLocation());
-                ArrayList<Claim> claimsInChunk = this.chunksToClaimsMap.get(chunkID);
-                if (claimsInChunk != null)
-                {
-                    for (Claim claim : claimsInChunk)
-                    {
-                        if (claim.inDataStore && claim.getLesserBoundaryCorner().getWorld().equals(location.getWorld()))
-                        {
-                            claims.add(claim);
-                        }
-                    }
-                }
-            }
-        }
-
-        return claims;
+        return getChunkClaims(
+                location.getWorld(),
+                new BoundingBox(location.subtract(150, 0, 150), location.clone().add(300, 0, 300)));
     }
 
     //deletes all the land claims in a specified world

--- a/src/main/java/me/ryanhamshire/GriefPrevention/util/BoundingBox.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/util/BoundingBox.java
@@ -5,6 +5,7 @@ import me.ryanhamshire.GriefPrevention.Claim;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.util.NumberConversions;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
@@ -28,7 +29,7 @@ public class BoundingBox implements Cloneable
 {
 
     /**
-     * Construct a new bounding box containing all of the given blocks.
+     * Construct a new bounding box containing all the given blocks.
      *
      * @param blocks a collection of blocks to construct a bounding box around
      * @return the bounding box
@@ -46,6 +47,31 @@ public class BoundingBox implements Cloneable
         {
             Block block = iterator.next();
             box.union(block.getX(), block.getY(), block.getZ());
+        }
+
+        return box;
+    }
+
+    /**
+     * Construct a new bounding box containing all the given block states.
+     *
+     * @param blocks a collection of blocks to construct a bounding box around
+     * @return the bounding box
+     */
+    public static @NotNull BoundingBox ofStates(@NotNull Collection<BlockState> blocks)
+    {
+        if (blocks.size() == 0) throw new IllegalArgumentException("Cannot create bounding box with no blocks!");
+
+        Iterator<BlockState> iterator = blocks.iterator();
+        // Initialize bounding box with first block
+        BlockState state = iterator.next();
+        BoundingBox box = new BoundingBox(state.getX(), state.getY(), state.getZ(), state.getX(), state.getY(), state.getZ(), false);
+
+        // Fill in rest of bounding box with remaining blocks.
+        while (iterator.hasNext())
+        {
+            state = iterator.next();
+            box.union(state.getX(), state.getY(), state.getZ());
         }
 
         return box;


### PR DESCRIPTION
Trees and portals effectively now use pistons' fast mode comparison. Some legal uses are blocked, but the speed should far outweigh some very niche edge cases.

This is a behavioral change for tree growth.
Old: GP allows tree to grow but removes all elements conflicting with claim
New: GP determines that there is not enough room for the tree to grow, prevents the growth, and breaks the sapling